### PR TITLE
$database can be null

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     }
   ],
   "require": {
+    "php": ">=7.1.0",
     "ext-zip": "*",
     "yiisoft/yii2-faker": "~2.0.0",
     "yiisoft/yii2-gii": "~2.1.0",

--- a/src/utils/DatabaseUtilsTrait.php
+++ b/src/utils/DatabaseUtilsTrait.php
@@ -30,7 +30,7 @@ trait DatabaseUtilsTrait
      *
      * @return array|null
      */
-    protected function getDatabase(string $database): ?string
+    protected function getDatabase(?string $database): ?string
     {
         if ($database === null) {
             return DatabaseUtils::getDsnAttribute($this->dbConnection->dsn);


### PR DESCRIPTION
Also nullables are only available since php 7.1, so we can define that as minimum in composer too.
